### PR TITLE
Add simple Point3D + Sphere

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![logo](https://github.com/JulienPeloton/spark3D/blob/master/pic/spark3d_logo.jpg)
 
-[![Build Status](https://travis-ci.org/JulienPeloton/spark3D.svg?branch=geometryObjects)](https://travis-ci.org/JulienPeloton/spark3D)
-[![codecov](https://codecov.io/gh/JulienPeloton/spark3D/branch/geometryObjects/graph/badge.svg)](https://codecov.io/gh/JulienPeloton/spark3D)
+[![Build Status](https://travis-ci.org/JulienPeloton/spark3D.svg?branch=master)](https://travis-ci.org/JulienPeloton/spark3D)
+[![codecov](https://codecov.io/gh/JulienPeloton/spark3D/branch/master/graph/badge.svg)](https://codecov.io/gh/JulienPeloton/spark3D)
 
 The package is under an active development! Here is the short term development list:
 

--- a/src/main/scala/com/spark3d/geometryObjects/Point3D.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/Point3D.scala
@@ -34,8 +34,6 @@ class Point3D(val x: Double, val y: Double, val z: Double) extends Shape3D {
   /**
     * Methods to determine whether two shapes overlap.
     * Implement different ways for different shapes.
-    * E.g. for sphere and point, we compare the distance between
-    * the two centers with the sum of the two radii.
     *
     * @param otherShape : (Shape3D)
     *   An instance of Shape3D (or extension)
@@ -47,12 +45,16 @@ class Point3D(val x: Double, val y: Double, val z: Double) extends Shape3D {
     // Different methods to handle different shapes
     // Keep in mind a point is a sphere with radius 0.
     if (otherShape.isInstanceOf[Sphere] | otherShape.isInstanceOf[Point3D]) {
-      val distance = center.distanceTo(otherShape.center)
-      val sumRadii = this.radius + otherShape.radius
-      if (sumRadii >= distance) {
-        true
-      } else false
-    } else false
+      sphereSphereIntersection(this, otherShape)
+    } else {
+      throw new AssertionError("""
+        Cannot perform intersection because the type of shape is unknown!
+        Currently implemented:
+          - sphere x sphere
+          - sphere x point
+          - point  x point
+        """)
+    }
   }
 
   /**

--- a/src/main/scala/com/spark3d/geometryObjects/Shape3D.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/Shape3D.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2018 Julien Peloton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spark3d.geometryObjects
+
+/**
+  * Generic objects describing 3D shapes.
+  * Other 3D shapes must extend this.
+  */
+object Shape3D extends Serializable {
+
+  /**
+    * Generic methods for 3D shapes
+    */
+  trait Shape3D {
+
+    /**
+      * The center
+      */
+    val center : Point3D
+
+    /**
+      * Radius of the Shape.
+      * Only meaningful for Sphere.
+      */
+    val radius : Double
+
+    /**
+      * Whether two shapes intersect each other.
+      *
+      * @param otherShape : (Geometry3D)
+      *   Other instance of Geometry3D
+      * @return (Boolean) True if they overlap. False otherwise.
+      */
+    def intersect(otherShape: Shape3D) : Boolean
+
+    /**
+      * Compute the volume of the 3D shape.
+      *
+      * @return (Double) the volume of the shape.
+      */
+    def getVolume : Double
+  }
+}

--- a/src/main/scala/com/spark3d/geometryObjects/Shape3D.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/Shape3D.scala
@@ -53,4 +53,41 @@ object Shape3D extends Serializable {
       */
     def getVolume : Double
   }
+
+  /**
+    * Intersection between two spheres. We compare the distance between
+    * the two centers with the sum of the two radii.
+    * Work also with points (sphere with zero radius).
+    *
+    * @param sphere1 : (Shape3D)
+    *   Instance of Shape3D, and more specifically Sphere.
+    * @param sphere2 : (Shape3D)
+    *   Instance of Shape3D, and more specifically Sphere.
+    */
+  def sphereSphereIntersection(sphere1: Shape3D, sphere2: Shape3D) : Boolean = {
+
+    // Quick check on the types of objects
+    if (!sphere1.isInstanceOf[Sphere] && !sphere1.isInstanceOf[Point3D]) {
+      throw new AssertionError("""
+        You are using sphereSphereIntersection with a non-spherical object
+        """)
+    }
+
+    if (!sphere2.isInstanceOf[Sphere] && !sphere2.isInstanceOf[Point3D]) {
+      throw new AssertionError("""
+        You are using sphereSphereIntersection with a non-spherical object
+        """)
+    }
+
+    // Compute the distance between the two centers
+    val distance = sphere1.center.distanceTo(sphere2.center)
+
+    // Compute the sum of the two sphere radii
+    val sumRadii = sphere1.radius + sphere2.radius
+
+    // Compare the distance between centers, and the radius sum.
+    if (sumRadii >= distance) {
+      true
+    } else false
+  }
 }

--- a/src/main/scala/com/spark3d/geometryObjects/Sphere.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/Sphere.scala
@@ -18,18 +18,21 @@ package com.spark3d.geometryObjects
 import com.spark3d.geometryObjects.Shape3D._
 
 /**
-  * Class for describing a point in 3D space.
+  * Class to handle a Sphere
+  *
+  * @param x : (Double)
+  *   X coordinate of the center
+  * @param y : (Double)
+  *   Y coordinate of the center
+  * @param z : (Double)
+  *   Z coordinate of the center
+  * @param radius : (Double)
+  *   Radius of the Sphere
   */
-class Point3D(val x: Double, val y: Double, val z: Double) extends Shape3D {
+class Sphere(val x: Double, val y: Double, val z: Double, override val radius: Double) extends Shape3D with Serializable {
 
-  // The center of the point is the point
-  val center : Point3D = this
-
-  // Zero radius
-  val radius : Double = 0.0
-
-  // Zero volume
-  override def getVolume : Double = 0.0
+  // Center of our Sphere
+  val center = new Point3D(this.x, this.y, this.z)
 
   /**
     * Methods to determine whether two shapes overlap.
@@ -56,28 +59,11 @@ class Point3D(val x: Double, val y: Double, val z: Double) extends Shape3D {
   }
 
   /**
-    * Returns the distance between the point and another.
-    * Space is supposed flat (euclidean).
-    *
-    * @param p : (Point3D)
-    *   Another instance of Point3D
-    * @return (Double) Distance between the two points.
+    * Volume of a Sphere.
+    * @return (Double) 4/3 * pi * R**3
     *
     */
-  def distanceTo(p : Point3D) : Double = {
-    val module = math.sqrt(
-      (this.x - p.x)*(this.x - p.x) +
-      (this.y - p.y)*(this.y - p.y) +
-      (this.z - p.z)*(this.z - p.z))
-    module
-  }
-
-  /**
-    * Return the coordinates (x, y, z) of the point.
-    *
-    * @return (List[Double]) The list of coordinates.
-    */
-  def getCoordinate : List[Double] = {
-    List(this.x, this.y, this.z)
+  override def getVolume : Double = {
+    4.0 / 3.0 * math.Pi * this.radius * this.radius * this.radius
   }
 }

--- a/src/main/scala/com/spark3d/geometryObjects/Sphere.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/Sphere.scala
@@ -37,8 +37,6 @@ class Sphere(val x: Double, val y: Double, val z: Double, override val radius: D
   /**
     * Methods to determine whether two shapes overlap.
     * Implement different ways for different shapes.
-    * E.g. for sphere and point, we compare the distance between
-    * the two centers with the sum of the two radii.
     *
     * @param otherShape : (Shape3D)
     *   An instance of Shape3D (or extension)
@@ -50,12 +48,16 @@ class Sphere(val x: Double, val y: Double, val z: Double, override val radius: D
     // Different methods to handle different shapes
     // Keep in mind a point is a sphere with radius 0.
     if (otherShape.isInstanceOf[Sphere] | otherShape.isInstanceOf[Point3D]) {
-      val distance = center.distanceTo(otherShape.center)
-      val sumRadii = this.radius + otherShape.radius
-      if (sumRadii >= distance) {
-        true
-      } else false
-    } else false
+      sphereSphereIntersection(this, otherShape)
+    } else {
+      throw new AssertionError("""
+        Cannot perform intersection because the type of shape is unknown!
+        Currently implemented:
+          - sphere x sphere
+          - sphere x point
+          - point  x point
+        """)
+    }
   }
 
   /**

--- a/src/test/scala/com/spark3d/geometryObjects/Point3DTest.scala
+++ b/src/test/scala/com/spark3d/geometryObjects/Point3DTest.scala
@@ -42,4 +42,24 @@ class Point3DTest extends FunSuite with BeforeAndAfterAll {
     val p1 = new Point3D(0.0, 1.0, 0.0)
     assert(p1.getCoordinate == List(0.0, 1.0, 0.0))
   }
+
+  // Test method to test whether two points intersect
+  test("Can you identify two different points?") {
+    val p1 = new Point3D(0.0, 1.0, 0.0)
+    val p2 = new Point3D(0.1, 1.0, 0.0)
+    assert(!p1.intersect(p2))
+  }
+
+  // Test method to test whether two points intersect
+  test("Can you identify two identical points?") {
+    val p1 = new Point3D(0.0, 1.0, 0.0)
+    val p2 = new Point3D(0.0, 1.0, 0.0)
+    assert(p1.intersect(p2))
+  }
+
+  // Volume of a point
+  test("Can you compute the volume of a point?") {
+    val sphere = new Point3D(0.0, 0.0, 0.0)
+    assert(sphere.getVolume == 0.0)
+  }
 }

--- a/src/test/scala/com/spark3d/geometryObjects/Point3DTest.scala
+++ b/src/test/scala/com/spark3d/geometryObjects/Point3DTest.scala
@@ -18,6 +18,26 @@ package com.spark3d.geometryObjects
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 import com.spark3d.geometryObjects._
+import com.spark3d.geometryObjects.Shape3D._
+
+/**
+  * Dummy class with no specific implementation to test errors
+  */
+class nonShape extends Shape3D {
+  // Centered in 0
+  val center : Point3D = new Point3D(0.0, 0.0, 0.0)
+
+  // Zero radius
+  val radius : Double = 0.0
+
+  // No intersection
+  override def intersect(otherShape : Shape3D) : Boolean = {
+    false
+  }
+
+  // Zero volume
+  override def getVolume : Double = 0.0
+}
 
 /**
   * Test class for the Point3DTest class.
@@ -59,7 +79,17 @@ class Point3DTest extends FunSuite with BeforeAndAfterAll {
 
   // Volume of a point
   test("Can you compute the volume of a point?") {
-    val sphere = new Point3D(0.0, 0.0, 0.0)
-    assert(sphere.getVolume == 0.0)
+    val p = new Point3D(0.0, 0.0, 0.0)
+    assert(p.getVolume == 0.0)
+  }
+
+  // Detect problems with unknown shape when doing intersection
+  test("Can you deal with unknown shape when doing intersection?") {
+    val p = new Point3D(0.0, 0.0, 0.0)
+    val wrong = new nonShape
+    val exception = intercept[AssertionError] {
+      p.intersect(wrong)
+    }
+    assert(exception.getMessage.contains("Cannot perform intersection"))
   }
 }

--- a/src/test/scala/com/spark3d/geometryObjects/Shape3DTest.scala
+++ b/src/test/scala/com/spark3d/geometryObjects/Shape3DTest.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2018 Julien Peloton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spark3d.geometryObjects
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+import com.spark3d.geometryObjects._
+import com.spark3d.geometryObjects.Shape3D._
+
+/**
+  * Test class for the Shape3D methods.
+  */
+class Shape3DTest extends FunSuite with BeforeAndAfterAll {
+  // Just test the Sphere class constructor.
+  test("Can you catch bad intersections between a spherical and a non-spherical object?") {
+    val p = new Point3D(0.0, 0.0, 0.0)
+    val wrong = new nonShape
+    val exception1 = intercept[AssertionError] {
+      sphereSphereIntersection(p, wrong)
+    }
+    assert(exception1.getMessage.contains("non-spherical object"))
+
+    val exception2 = intercept[AssertionError] {
+      sphereSphereIntersection(wrong, p)
+    }
+    assert(exception2.getMessage.contains("non-spherical object"))
+  }
+}

--- a/src/test/scala/com/spark3d/geometryObjects/SphereTest.scala
+++ b/src/test/scala/com/spark3d/geometryObjects/SphereTest.scala
@@ -18,7 +18,7 @@ package com.spark3d.geometryObjects
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 /**
-  * Test class for the Point3DTest class.
+  * Test class for the Sphere class.
   */
 class SphereTest extends FunSuite with BeforeAndAfterAll {
 
@@ -53,5 +53,14 @@ class SphereTest extends FunSuite with BeforeAndAfterAll {
   test("Can you compute the volume of a sphere?") {
     val sphere = new Sphere(0.0, 0.0, 0.0, 3.0)
     assert(sphere.getVolume == 36 * math.Pi)
+  }
+
+  test("Can you deal with unknown shape when doing intersection?") {
+    val p = new Sphere(0.0, 0.0, 0.0, 1.0)
+    val wrong = new nonShape
+    val exception = intercept[AssertionError] {
+      p.intersect(wrong)
+    }
+    assert(exception.getMessage.contains("Cannot perform intersection"))
   }
 }

--- a/src/test/scala/com/spark3d/geometryObjects/SphereTest.scala
+++ b/src/test/scala/com/spark3d/geometryObjects/SphereTest.scala
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018 Julien Peloton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spark3d.geometryObjects
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+/**
+  * Test class for the Point3DTest class.
+  */
+class SphereTest extends FunSuite with BeforeAndAfterAll {
+
+  // Just test the Sphere class constructor.
+  test("Can you initialise a Sphere?") {
+    val sphere = new Sphere(0.0, 0.0, 0.0, 1.0)
+    assert(sphere.isInstanceOf[Sphere])
+  }
+
+  // Are two spheres overlapping?
+  test("Can you detect that 2 spheres are overlapping?") {
+    val sphere1 = new Sphere(0.0, 0.0, 0.0, 1.0)
+    val sphere2 = new Sphere(1.0, 1.0, 1.0, 1.0)
+    assert(sphere1.intersect(sphere2))
+  }
+
+  // Are two spheres overlapping?
+  test("Can you detect that 2 spheres are not overlapping?") {
+    val sphere1 = new Sphere(0.0, 0.0, 0.0, 0.5)
+    val sphere2 = new Sphere(5.0, 5.0, 5.0, 0.5)
+    assert(!sphere1.intersect(sphere2))
+  }
+
+  // Are a sphere and a point overlapping?
+  test("Can you detect that a point lies inside a sphere?") {
+    val sphere = new Sphere(0.0, 0.0, 0.0, 1.0)
+    val point = new Point3D(0.0, 0.5, 0.0)
+    assert(sphere.intersect(point) && point.intersect(sphere))
+  }
+
+  // Volume of a sphere
+  test("Can you compute the volume of a sphere?") {
+    val sphere = new Sphere(0.0, 0.0, 0.0, 3.0)
+    assert(sphere.getVolume == 36 * math.Pi)
+  }
+}


### PR DESCRIPTION
I just added simple classes to deal with Point in a 3D space and Sphere:

```scala
val point = new Point3D(x, y, z)
val sphere = new Sphere(x, y, z, radius)
```

They both extend the trait Shape3D.