### PR TITLE
Write the partitioner in the spirit of Scala (no more Java-like)

### DIFF
--- a/src/main/scala/com/spark3d/spatialOperator/CenterCrossMatch.scala
+++ b/src/main/scala/com/spark3d/spatialOperator/CenterCrossMatch.scala
@@ -150,6 +150,16 @@ object CenterCrossMatch {
   def CrossMatchCenter[A<:Shape3D : ClassTag, B<:Shape3D : ClassTag](
       rddA: RDD[A], rddB: RDD[B], epsilon: Double, returnType: String = "B"): RDD[_] = {
 
+    // Check that the two RDD have the same partitioning.
+    if (rddA.partitioner != rddB.partitioner) {
+      throw new AssertionError("""
+        The two RDD must be partitioned by the same partitioner to perform
+        a cross-match! Use spatialPartitioning(rddA.partitioner) to apply
+        a spatial partitioning to a Shape3D RDD.
+        """
+      )
+    }
+    
     // Catch unphysical conditions
     if (epsilon < 0.0) {
       throw new AssertionError("""

--- a/src/main/scala/com/spark3d/spatialPartitioning/OnionPartitioner.scala
+++ b/src/main/scala/com/spark3d/spatialPartitioning/OnionPartitioner.scala
@@ -47,7 +47,7 @@ class OnionPartitioner(grids : List[ShellEnvelope]) extends SpatialPartitioner(g
     * difference between 2 concentric spheres. The n partitions
     * will contain the objects lying in our Onion space.
     *
-    * @return (Int) the number of partition
+    * @return (Int) the number of partitions
     */
   override def numPartitions : Int = {
     grids.size
@@ -55,6 +55,8 @@ class OnionPartitioner(grids : List[ShellEnvelope]) extends SpatialPartitioner(g
 
   /**
     * Hashcode returns the number of partitions.
+    *
+    * @return (Int) the number of partitions
     */
   override def hashCode: Int = numPartitions
 

--- a/src/main/scala/com/spark3d/spatialPartitioning/OnionPartitioner.scala
+++ b/src/main/scala/com/spark3d/spatialPartitioning/OnionPartitioner.scala
@@ -15,14 +15,17 @@
  */
 package com.spark3d.spatialPartitioning
 
-import collection.JavaConverters._
+// import collection.JavaConverters._
 
+// Scala deps
+import scala.util.control.Breaks._
 import scala.collection.mutable.HashSet
 
+// spark3d deps
 import com.spark3d.geometry.ShellEnvelope
 import com.spark3d.spatialPartitioning
 import com.spark3d.geometryObjects.Shape3D._
-import scala.util.control.Breaks._
+
 
 /**
   * Class extending SpatialPartitioner to deal with the onion space.
@@ -51,6 +54,11 @@ class OnionPartitioner(grids : List[ShellEnvelope]) extends SpatialPartitioner(g
   }
 
   /**
+    * Hashcode returns the number of partitions.
+    */
+  override def hashCode: Int = numPartitions
+
+  /**
     * Associate geometrical objects (Point3D, Sphere, etc) to
     * grid elements (partition) of the onion space. The association is done
     * according to the position of the center of the object (we do not deal
@@ -60,17 +68,18 @@ class OnionPartitioner(grids : List[ShellEnvelope]) extends SpatialPartitioner(g
     * @param spatialObject : (T<:Shape3D)
     *   Shape3D instance (or any extension) representing objects to put on
     *   the grid.
-    * @return (java.util.Iterator[Tuple2[Int, T]]) Java iterator over a Tuple
-    *   of (Int, T) where Int is the partition number, and T the input object.
+    * @return (Iterator[Tuple2[Int, T]]) Iterable over a Tuple
+    *   of (Int, T) where Int is the partition index, and T the input object.
     *
     */
-  override def placeObject[T<:Shape3D](spatialObject : T) : java.util.Iterator[Tuple2[Int, T]] = {
+  override def placeObject[T<:Shape3D](spatialObject : T) : Iterator[Tuple2[Int, T]] = {
 
     // Grab the center of the geometrical objects
     val center = spatialObject.center
     var containFlag : Boolean = false
     val notIncludedID = grids.size - 1
     val result = HashSet.empty[Tuple2[Int, T]]
+
 
     // Associate the object with one shell
     breakable {
@@ -90,8 +99,7 @@ class OnionPartitioner(grids : List[ShellEnvelope]) extends SpatialPartitioner(g
       result += new Tuple2(notIncludedID, spatialObject)
     }
 
-    // Make it Java for GeoSpark compatibility
-    result.toIterator.asJava
+    // Return an iterator
+    result.iterator
   }
-
 }

--- a/src/main/scala/com/spark3d/spatialPartitioning/SpatialPartitioner.scala
+++ b/src/main/scala/com/spark3d/spatialPartitioning/SpatialPartitioner.scala
@@ -15,10 +15,11 @@
  */
 package com.spark3d.spatialPartitioning
 
+// Spark built-in partitioner
 import org.apache.spark.Partitioner
 
+// spark3d deps
 import com.spark3d.geometry.Envelope
-import com.spark3d.utils.GridType._
 import com.spark3d.geometryObjects.Shape3D._
 
 /**
@@ -41,12 +42,12 @@ abstract class SpatialPartitioner(grids : List[Envelope]) extends Partitioner wi
     *
     * @param spatialObject : (T<:Shape3D)
     *   Object of type T = Shape3D, or any extension like Point3D, Sphere, ...
-    * @return (java.util.Iterator[Tuple2[Int, T]]) Java Iterator over
+    * @return (Iterator[Tuple2[Int, T]]) Iterator over
     *   a tuple (Key, Object). Key represents the partition number to which the
     *   spatialObject T belongs to.
     *
     */
-  def placeObject[T<:Shape3D](spatialObject : T) : java.util.Iterator[Tuple2[Int, T]] = ???
+  def placeObject[T<:Shape3D](spatialObject : T) : Iterator[Tuple2[Int, T]] = ???
 
   /**
     * Method to return the index of a partition

--- a/src/test/scala/com/spark3d/spatialPartitioning/OnionPartitionerTest.scala
+++ b/src/test/scala/com/spark3d/spatialPartitioning/OnionPartitionerTest.scala
@@ -67,4 +67,13 @@ class OnionPartitionerTest extends FunSuite with BeforeAndAfterAll {
     // 9 partitions for inside
     assert(partitioner.numPartitions == 9)
   }
+
+  test("Can you output the hashCode correctly?") {
+    val partitioning = new OnionPartitioning
+    partitioning.LinearOnionPartitioning(9, 1.0, false)
+    val grids = partitioning.getGrids
+    val partitioner = new OnionPartitioner(grids)
+
+    assert(partitioner.hashCode == 9)
+  }
 }


### PR DESCRIPTION
Small PR - mostly cleanup of the current code.
* Considerably reduce the `partition` method in `Shape3DRDD` using Scala methods instead of Java-like style code. Remove Java-style piece of codes here and there.
* Catch error when trying to perform cross-match with 2 RDD with different partitioners.