### PR TITLE
Window query

### DIFF
--- a/src/main/scala/com/spark3d/geometryObjects/BoxEnvelope.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/BoxEnvelope.scala
@@ -420,7 +420,7 @@ class BoxEnvelope private(
     * @return (Boolean) true if the two objects intersect.
     *
     */
-  def intersects(otherShape: Shape3D): Boolean = {
+  override def intersects(otherShape: Shape3D): Boolean = {
 
     // Different methods to handle different shapes
     if (otherShape.isInstanceOf[Point3D]) {

--- a/src/main/scala/com/spark3d/geometryObjects/BoxEnvelope.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/BoxEnvelope.scala
@@ -426,6 +426,12 @@ class BoxEnvelope private(
     if (otherShape.isInstanceOf[Point3D]) {
       this.covers(otherShape.asInstanceOf[Point3D])
     } else if (otherShape.isInstanceOf[ShellEnvelope]) {
+      // This is not perfect. We take the bounding box around the shell
+      // and perform the intersection between boxes.
+      // Potential bugs:
+      //  - if the box is within the inner shell
+      //  - if the box is just outside the outer shell
+      // TODO: Implement real shell - box intersection.
       val env = otherShape.asInstanceOf[ShellEnvelope].getEnvelope
       this.intersectsBox(env)
     } else if (otherShape.isInstanceOf[BoxEnvelope]) {

--- a/src/main/scala/com/spark3d/geometryObjects/BoxEnvelope.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/BoxEnvelope.scala
@@ -411,6 +411,37 @@ class BoxEnvelope private(
     new BoxEnvelope(intMinX, intMaxX, intMinY, intMaxY, intMinZ, intMaxZ)
   }
 
+  /**
+    * Methods to determine whether the Box intersects another shape.
+    * Implement different ways for different shapes (Point, Shell, Box available).
+    *
+    * @param otherShape : (Shape3D)
+    *   An instance of Shape3D (or extension)
+    * @return (Boolean) true if the two objects intersect.
+    *
+    */
+  def intersects(otherShape: Shape3D): Boolean = {
+
+    // Different methods to handle different shapes
+    if (otherShape.isInstanceOf[Point3D]) {
+      this.covers(otherShape.asInstanceOf[Point3D])
+    } else if (otherShape.isInstanceOf[ShellEnvelope]) {
+      val env = otherShape.asInstanceOf[ShellEnvelope].getEnvelope
+      this.intersectsBox(env)
+    } else if (otherShape.isInstanceOf[BoxEnvelope]) {
+      this.intersectsBox(otherShape.asInstanceOf[BoxEnvelope])
+    } else {
+      throw new AssertionError(
+        """
+        Cannot perform intersection because the type of shape is unknown!
+        Currently implemented:
+          - box x point
+          - box x sphere
+          - box x box
+        """)
+    }
+  }
+
 
   /**
     * Checks if the region of the input cube Envelope intersects the region of this cube Envelope.
@@ -418,7 +449,7 @@ class BoxEnvelope private(
     * @param env the cube Envelope with which the intersection is being checked
     * @return true if the cube Envelope intersects the other cube Envelope
     */
-  def intersects(env: BoxEnvelope): Boolean = {
+  def intersectsBox(env: BoxEnvelope): Boolean = {
     if (env.isNull) {
       return false
     }
@@ -441,7 +472,7 @@ class BoxEnvelope private(
     * @param p3 the third external point (cartesian coordinate)
     * @return true if the region intersects the other cube Envelope
     */
-  def intersects(p1: Point3D, p2: Point3D, p3: Point3D): Boolean = {
+  def intersectsRegion(p1: Point3D, p2: Point3D, p3: Point3D): Boolean = {
     if (p1.isSpherical | p2.isSpherical | p3.isSpherical) {
       throw new AssertionError("""
         All input Point3D for creating a region must have cartesian coordinate system!

--- a/src/main/scala/com/spark3d/geometryObjects/Point3D.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/Point3D.scala
@@ -53,7 +53,7 @@ class Point3D(val x: Double, val y: Double, val z: Double,
     * @return (Boolean) true if the two objects intersect.
     *
     */
-  def intersect(otherShape: Shape3D): Boolean = {
+  def intersects(otherShape: Shape3D): Boolean = {
 
     // Different methods to handle different shapes
     if (otherShape.isInstanceOf[Point3D]) {

--- a/src/main/scala/com/spark3d/geometryObjects/Point3D.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/Point3D.scala
@@ -45,7 +45,7 @@ class Point3D(val x: Double, val y: Double, val z: Double,
   def getVolume: Double = 0.0
 
   /**
-    * Methods to determine whether two shapes overlap.
+    * Methods to determine whether the Point3D is contained in another shape.
     * Implement different ways for different shapes (Point, Shell, Box available).
     *
     * @param otherShape : (Shape3D)
@@ -68,7 +68,7 @@ class Point3D(val x: Double, val y: Double, val z: Double,
         Cannot perform intersection because the type of shape is unknown!
         Currently implemented:
           - point x point
-          - poont x sphere
+          - point x sphere
           - point x box
         """)
     }

--- a/src/main/scala/com/spark3d/geometryObjects/Point3D.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/Point3D.scala
@@ -53,7 +53,7 @@ class Point3D(val x: Double, val y: Double, val z: Double,
     * @return (Boolean) true if the two objects intersect.
     *
     */
-  def intersects(otherShape: Shape3D): Boolean = {
+  override def intersects(otherShape: Shape3D): Boolean = {
 
     // Different methods to handle different shapes
     if (otherShape.isInstanceOf[Point3D]) {

--- a/src/main/scala/com/spark3d/geometryObjects/Shape3D.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/Shape3D.scala
@@ -45,6 +45,17 @@ object Shape3D extends Serializable {
     def getEnvelope: BoxEnvelope
 
     /**
+      * Methods to determine whether the Shape3D is contained in another Shape3D.
+      * Implement different ways for different shapes (Point, Shell, Box available).
+      *
+      * @param otherShape : (Shape3D)
+      *   An instance of Shape3D (or extension)
+      * @return (Boolean) true if the two objects intersect.
+      *
+      */
+    def intersects(otherShape: Shape3D): Boolean
+
+    /**
       * Compute the healpix index of the geometry center.
       * By default, the method considers that this.y = ra, this.z = dec.
       * You can also bypass that, and force this.y = theta, this.z = phi by

--- a/src/main/scala/com/spark3d/geometryObjects/ShellEnvelope.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/ShellEnvelope.scala
@@ -242,6 +242,43 @@ class ShellEnvelope(
   }
 
   /**
+    * Methods to determine whether the Shell intersects another shape.
+    * Implement different ways for different shapes (Point, Shell, Box available).
+    *
+    * @param otherShape : (Shape3D)
+    *   An instance of Shape3D (or extension)
+    * @return (Boolean) true if the two objects intersect.
+    *
+    */
+  def intersects(otherShape: Shape3D): Boolean = {
+
+    // Different methods to handle different shapes
+    if (otherShape.isInstanceOf[Point3D]) {
+      this.isPointInShell(otherShape.asInstanceOf[Point3D])
+    } else if (otherShape.isInstanceOf[ShellEnvelope]) {
+      this.intersectsShell(otherShape.asInstanceOf[ShellEnvelope])
+    } else if (otherShape.isInstanceOf[BoxEnvelope]) {
+      // This is not perfect. We take the bounding box around the shell
+      // and perform the intersection between boxes.
+      // Potential bugs:
+      //  - if the box is within the inner shell
+      //  - if the box is just outside the outer shell
+      // TODO: Implement real shell - box intersection.
+      val env = this.getEnvelope
+      otherShape.asInstanceOf[BoxEnvelope].intersectsBox(env)
+    } else {
+      throw new AssertionError(
+        """
+        Cannot perform intersection because the type of shape is unknown!
+        Currently implemented:
+          - sphere x point
+          - sphere x sphere
+          - sphere x box
+        """)
+    }
+  }
+
+  /**
     * Checks if the region of the input shell Envelope intersects the region of this shell Envelope.
     * The case where one shell Envelope lies completely within the another shell Envelope is considered as
     * non-intersecting.
@@ -249,7 +286,7 @@ class ShellEnvelope(
     * @param spr the shell Envelope with which the intersection is being checked
     * @return true if the one shell Envelope intersects the other
     */
-  def intersects(spr: ShellEnvelope): Boolean = {
+  def intersectsShell(spr: ShellEnvelope): Boolean = {
     if (isNull || spr.isNull) {
       return false
     }

--- a/src/main/scala/com/spark3d/geometryObjects/ShellEnvelope.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/ShellEnvelope.scala
@@ -250,7 +250,7 @@ class ShellEnvelope(
     * @return (Boolean) true if the two objects intersect.
     *
     */
-  def intersects(otherShape: Shape3D): Boolean = {
+  override def intersects(otherShape: Shape3D): Boolean = {
 
     // Different methods to handle different shapes
     if (otherShape.isInstanceOf[Point3D]) {

--- a/src/main/scala/com/spark3d/spatialOperator/RangeQuery.scala
+++ b/src/main/scala/com/spark3d/spatialOperator/RangeQuery.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2018 Julien Peloton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spark3d.spatialOperator
+
+import scala.reflect.ClassTag
+
+import com.spark3d.geometryObjects.Shape3D._
+
+import com.spark3d.spatial3DRDD.Shape3DRDD
+
+import org.apache.spark.rdd.RDD
+
+object RangeQuery {
+
+  /**
+    *
+    */
+  def windowQuery[A<:Shape3D : ClassTag, B<:Shape3D : ClassTag](
+    rdd: RDD[A], enveloppeWindow: B): RDD[A] = {
+      // Just intersection -- need to implement full coverage
+      rdd.filter(element => element.intersects(enveloppeWindow))
+    }
+  // /**
+  //   *
+  //   */
+  // def windowQuery[A<:Shape3D : ClassTag, B<:Shape3D : ClassTag](
+  //   element: A, enveloppeWindow: B): Boolean = {
+  //     // Just intersection -- need to implement full coverage
+  //     element.intersects(enveloppeWindow)
+  //   }
+}

--- a/src/main/scala/com/spark3d/utils/Utils.scala
+++ b/src/main/scala/com/spark3d/utils/Utils.scala
@@ -27,7 +27,7 @@ object Utils {
     *   Input Point3D with cartesian coordinates.
     * @return (Point3D) The same point but with spherical coordinates.
     */
-  def cartesiantoSpherical(p : Point3D) : Point3D = {
+  def cartesianToSpherical(p : Point3D) : Point3D = {
     if (p.isSpherical) {
       throw new AssertionError("""
         Cannot convert your point to spherical coordinates because

--- a/src/test/scala/com/spark3d/geometryObjects/BoxEnvelopeTest.scala
+++ b/src/test/scala/com/spark3d/geometryObjects/BoxEnvelopeTest.scala
@@ -318,17 +318,42 @@ class BoxEnvelopeTest extends FunSuite with BeforeAndAfterAll {
     val env = new BoxEnvelope(p1, p2, p3)
 
     assert(valid_env.intersects(env))
-    assert(valid_env.intersects(p1, p2, p3))
+    assert(valid_env.intersectsRegion(p1, p2, p3))
 
     val p1Sph = new Point3D(0.0, 1.0, 0.0, true)
     val p2Cart = new Point3D(0.1, 4.0, 0.0, isSpherical)
     val p3Cart = new Point3D(1.0, -1.0, 1.3, isSpherical)
 
     val exception = intercept[AssertionError] {
-      valid_env.intersects(p1Sph, p2Cart, p3Cart)
+      valid_env.intersectsRegion(p1Sph, p2Cart, p3Cart)
     }
     assert(exception.getMessage.contains("must have cartesian coordinate system"))
 
+  }
+
+  test("Can you test if cube and shell envelopes intersect?") {
+
+    assert(!valid_env.intersects(null_env))
+
+    val p1 = new Point3D(0.0, 1.0, 0.0, isSpherical)
+    val p2 = new Point3D(0.1, 4.0, 0.0, isSpherical)
+    val p3 = new Point3D(1.0, -1.0, 1.3, isSpherical)
+    val envCube = new BoxEnvelope(p1, p2, p3)
+    val envSphere = new ShellEnvelope(p1, 1.0)
+
+    assert(envCube.intersects(envSphere))
+  }
+
+  test("Can you test if cube and point intersect?") {
+
+    assert(!valid_env.intersects(null_env))
+
+    val p1 = new Point3D(0.0, 1.0, 0.0, isSpherical)
+    val p2 = new Point3D(0.1, 4.0, 0.0, isSpherical)
+    val p3 = new Point3D(1.0, -1.0, 1.3, isSpherical)
+    val envCube = new BoxEnvelope(p1, p2, p3)
+
+    assert(envCube.intersects(p1))
   }
 
   test("Can you test if the point intersects the cube Envelope?") {
@@ -341,23 +366,23 @@ class BoxEnvelopeTest extends FunSuite with BeforeAndAfterAll {
 
     //test for intersection in x-plane
     val p0: Point3D = new Point3D(12.2, 4.2, 12.2, isSpherical)
-    assert(!valid_env.intersects(p0, p0, p0))
+    assert(!valid_env.intersectsRegion(p0, p0, p0))
     val p1: Point3D = new Point3D(-12.2, 4.2, 12.2, isSpherical)
-    assert(!valid_env.intersects(p1, p1, p1))
+    assert(!valid_env.intersectsRegion(p1, p1, p1))
 
     //test for intersection in y-plane
     val p2: Point3D = new Point3D(5.4, -12.2, 12.2, isSpherical)
-    assert(!valid_env.intersects(p2, p2, p2))
+    assert(!valid_env.intersectsRegion(p2, p2, p2))
     val p3: Point3D = new Point3D(5.4, 12.2, 12.2, isSpherical)
-    assert(!valid_env.intersects(p3, p3, p3))
+    assert(!valid_env.intersectsRegion(p3, p3, p3))
 
     //test for intersection in z-plane
     val p4: Point3D = new Point3D(5.4, 5.4, -12.2, isSpherical)
-    assert(!valid_env.intersects(p4, p4, p4))
+    assert(!valid_env.intersectsRegion(p4, p4, p4))
     val p5: Point3D = new Point3D(5.4, 5.4, 12.2, isSpherical)
-    assert(!valid_env.intersects(p5, p5, p5))
+    assert(!valid_env.intersectsRegion(p5, p5, p5))
 
-    assert(!null_env.intersects(p5, p5, p5))
+    assert(!null_env.intersectsRegion(p5, p5, p5))
   }
 
   test("Can you test if the point lies inside of the cube Envelope?") {

--- a/src/test/scala/com/spark3d/geometryObjects/Point3DTest.scala
+++ b/src/test/scala/com/spark3d/geometryObjects/Point3DTest.scala
@@ -27,6 +27,8 @@ class nonShape extends Shape3D {
   val center : Point3D = new Point3D(0.0, 0.0, 0.0, true)
 
   def getEnvelope: BoxEnvelope = ???
+
+  def intersects(otherShape: Shape3D): Boolean = ???
 }
 
 /**

--- a/src/test/scala/com/spark3d/geometryObjects/Point3DTest.scala
+++ b/src/test/scala/com/spark3d/geometryObjects/Point3DTest.scala
@@ -64,20 +64,20 @@ class Point3DTest extends FunSuite with BeforeAndAfterAll {
   test("Can you identify two different points?") {
     val p1 = new Point3D(0.0, 1.0, 0.0, false)
     val p2 = new Point3D(0.1, 1.0, 0.0, false)
-    assert(!p1.intersect(p2))
+    assert(!p1.intersects(p2))
   }
 
   // Test method to test whether two points intersect
   test("Can you identify two identical points?") {
     val p1 = new Point3D(0.0, 1.0, 0.0, false)
     val p2 = new Point3D(0.0, 1.0, 0.0, false)
-    assert(p1.intersect(p2))
+    assert(p1.intersects(p2))
   }
 
   test("Can you intersect a point and a Shell?") {
     val p1 = new Point3D(0.0, 1.0, 0.0, false)
     val shell = new ShellEnvelope(0.0, 1.0, 0.0, true, 0.0, 10.0)
-    assert(p1.intersect(shell))
+    assert(p1.intersects(shell))
   }
 
   test("Can you intersect a point and a Box?") {
@@ -86,7 +86,7 @@ class Point3DTest extends FunSuite with BeforeAndAfterAll {
     val p3 = new Point3D(0.0, 10.0, 0.0, false)
     val p4 = new Point3D(0.0, 0.0, 10.0, false)
     val box = new BoxEnvelope(p2, p3, p4)
-    assert(p1.intersect(box))
+    assert(p1.intersects(box))
   }
 
   test("Can you catch an error trying to intersect a point with spherical coordinate and a Box?") {
@@ -97,7 +97,7 @@ class Point3DTest extends FunSuite with BeforeAndAfterAll {
     val box = new BoxEnvelope(p2, p3, p4)
 
     val exception = intercept[AssertionError] {
-      p1.intersect(box)
+      p1.intersects(box)
     }
     assert(exception.getMessage.contains("must have cartesian coordinate system"))
 
@@ -137,7 +137,7 @@ class Point3DTest extends FunSuite with BeforeAndAfterAll {
     val p = new Point3D(0.0, 0.0, 0.0, true)
     val wrong = new nonShape
     val exception = intercept[AssertionError] {
-      p.intersect(wrong)
+      p.intersects(wrong)
     }
     assert(exception.getMessage.contains("Cannot perform intersection"))
   }

--- a/src/test/scala/com/spark3d/geometryObjects/ShellEnvelopeTest.scala
+++ b/src/test/scala/com/spark3d/geometryObjects/ShellEnvelopeTest.scala
@@ -219,6 +219,32 @@ class ShellEnvelopeTest extends FunSuite with BeforeAndAfterAll {
 
   }
 
+  test("Can you check if a shell and a point intersect each other?") {
+    val env = new ShellEnvelope(valid_env)
+    assert(!null_env.intersects(env))
+
+    env.innerRadius = 0.0
+    env.outerRadius = 4.0
+
+    val p = new Point3D(1.0, 1.0, 1.0, isSpherical)
+    assert(env.intersects(p))
+
+    val p2 = new Point3D(10.0, 10.0, 10.0, isSpherical)
+    assert(!env.intersects(p2))
+
+  }
+
+  test("Can you check if a shell and a box Envelope intersect each other?") {
+
+    val p1 = new Point3D(0.0, 1.0, 0.0, isSpherical)
+    val p2 = new Point3D(0.1, 4.0, 0.0, isSpherical)
+    val p3 = new Point3D(1.0, -1.0, 1.3, isSpherical)
+    val envCube = new BoxEnvelope(p1, p2, p3)
+    val envSphere = new ShellEnvelope(p1, 1.0)
+
+    assert(envSphere.intersects(envCube))
+  }
+
   test("Can you check if the input shell Envelope is completely contained by the another shell Envelope?") {
     val env = new ShellEnvelope(valid_env)
 

--- a/src/test/scala/com/spark3d/spatialOperator/CenterCrossMatchTest.scala
+++ b/src/test/scala/com/spark3d/spatialOperator/CenterCrossMatchTest.scala
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.spark3d.spatial3DRDD
+package com.spark3d.spatialOperator
 
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 import com.spark3d.utils.GridType
 import com.spark3d.spatial3DRDD._
 import com.spark3d.spatialPartitioning.SpatialPartitioner
-import com.spark3d.spatialOperator.CenterCrossMatch
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._

--- a/src/test/scala/com/spark3d/spatialOperator/PixelCrossMatchTest.scala
+++ b/src/test/scala/com/spark3d/spatialOperator/PixelCrossMatchTest.scala
@@ -13,14 +13,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.spark3d.spatial3DRDD
+package com.spark3d.spatialOperator
 
 import org.scalatest.{BeforeAndAfterAll, FunSuite}
 
 import com.spark3d.utils.GridType
 import com.spark3d.spatial3DRDD._
 import com.spark3d.spatialPartitioning.SpatialPartitioner
-import com.spark3d.spatialOperator.PixelCrossMatch
 
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.types._

--- a/src/test/scala/com/spark3d/spatialOperator/RangeQueryTest.scala
+++ b/src/test/scala/com/spark3d/spatialOperator/RangeQueryTest.scala
@@ -1,0 +1,78 @@
+/*
+ * Copyright 2018 Julien Peloton
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.spark3d.spatialOperator
+
+import org.scalatest.{BeforeAndAfterAll, FunSuite}
+
+import com.spark3d.spatial3DRDD._
+import com.spark3d.geometryObjects.ShellEnvelope
+import com.spark3d.geometryObjects.Point3D
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.functions._
+
+import org.apache.log4j.Level
+import org.apache.log4j.Logger
+
+/**
+  * Test class for the Point3DRDD class.
+  */
+class RangeQueryTest extends FunSuite with BeforeAndAfterAll {
+
+  // Set to Level.WARN is you want verbosity
+  Logger.getLogger("org").setLevel(Level.OFF)
+  Logger.getLogger("akka").setLevel(Level.OFF)
+
+  private val master = "local[2]"
+  private val appName = "spark3dtest"
+
+  private var spark : SparkSession = _
+
+  override protected def beforeAll() : Unit = {
+    super.beforeAll()
+    spark = SparkSession
+      .builder()
+      .master(master)
+      .appName(appName)
+      .getOrCreate()
+  }
+
+  override protected def afterAll(): Unit = {
+    try {
+      spark.sparkContext.stop()
+    } finally {
+      super.afterAll()
+    }
+  }
+  // END TODO
+
+  // Test files
+  val fn = "src/test/resources/astro_obs_A_light.fits"
+
+  test("Can you find all points within a given region?") {
+
+    val pRDD = new Point3DRDDFromFITS(spark, fn, 1, "Z_COSMO,RA,DEC", true)
+
+    // Window is a Sphere centered on (0.05, 0.05, 0.05) and radius 0.1.
+    val p = new Point3D(0.05, 0.05, 0.05, true)
+    val window = new ShellEnvelope(p, 0.1)
+
+    val matches = RangeQuery.windowQuery(pRDD.rawRDD, window)
+
+    assert(matches.count() == 182)
+  }
+}

--- a/src/test/scala/com/spark3d/utils/UtilsTest.scala
+++ b/src/test/scala/com/spark3d/utils/UtilsTest.scala
@@ -28,7 +28,7 @@ class UtilsTest extends FunSuite with BeforeAndAfterAll {
   // Cartesian -> Spherical -> Cartesian
   test("Can you convert a Point3D with cartesian coordinate into spherical coordinate, and vice versa?") {
     val p_euc = new Point3D(1.0, 1.0, 0.0, false)
-    val p_sph = cartesiantoSpherical(p_euc)
+    val p_sph = cartesianToSpherical(p_euc)
     val p_sph_euc = sphericalToCartesian(p_sph)
     assert(
       math.rint(p_euc.x) == math.rint(p_sph_euc.x) &&
@@ -48,7 +48,7 @@ class UtilsTest extends FunSuite with BeforeAndAfterAll {
     // Spherical
     val p_sph = new Point3D(0.0, 0.0, 0.0, true)
     val exception2 = intercept[AssertionError] {
-      cartesiantoSpherical(p_sph)
+      cartesianToSpherical(p_sph)
     }
     assert(exception2.getMessage.contains("already in spherical coordinates"))
   }


### PR DESCRIPTION
This PR introduces new method to perform window query, that is match between RDD elements and a user-defined window (point, shell, box). The basic idea is:

```scala
// Need to be RDD[Shape3D]
val rdd = ...

// Window can be any Shape3D
val window = new ShellEnvelope(center, radius)

// Perform the query and returns matches
val matches = RangeQuery.windowQuery(rdd, window)
```

In addition, I uniformed the `intersects` method in all Shape3D sub-classes. 