### PR TITLE
Point3D: Coordinate fix when computing the distance btw points

### DIFF
--- a/src/main/scala/com/spark3d/geometryObjects/Point3D.scala
+++ b/src/main/scala/com/spark3d/geometryObjects/Point3D.scala
@@ -91,6 +91,7 @@ class Point3D(val x: Double, val y: Double, val z: Double,
 
   /**
     * Returns the distance between the point and another.
+    * The two points must have the same coordinate system.
     * Space is supposed flat (euclidean).
     *
     * @param p : (Point3D)
@@ -99,6 +100,14 @@ class Point3D(val x: Double, val y: Double, val z: Double,
     *
     */
   def distanceTo(p: Point3D): Double = {
+    if (p.isSpherical != this.isSpherical) {
+      throw new AssertionError("""
+        The 2 points must have the same coordinate system to compute
+        the distance! Convert one using sphericalToCartesian or
+        cartesianToSpherical methods.
+        """)
+    }
+
     val module = if (!this.isSpherical) {
       math.sqrt(
         (this.x - p.x) * (this.x - p.x) +

--- a/src/test/scala/com/spark3d/geometryObjects/Point3DTest.scala
+++ b/src/test/scala/com/spark3d/geometryObjects/Point3DTest.scala
@@ -77,8 +77,8 @@ class Point3DTest extends FunSuite with BeforeAndAfterAll {
   }
 
   test("Can you intersect a point and a Shell?") {
-    val p1 = new Point3D(0.0, 1.0, 0.0, false)
-    val shell = new ShellEnvelope(0.0, 1.0, 0.0, true, 0.0, 10.0)
+    val p1 = new Point3D(0.5, 0.0, 0.0, true)
+    val shell = new ShellEnvelope(0.0, 0.0, 0.0, true, 0.0, 10.0)
     assert(p1.intersects(shell))
   }
 

--- a/src/test/scala/com/spark3d/geometryObjects/Point3DTest.scala
+++ b/src/test/scala/com/spark3d/geometryObjects/Point3DTest.scala
@@ -80,6 +80,12 @@ class Point3DTest extends FunSuite with BeforeAndAfterAll {
     val p1 = new Point3D(0.5, 0.0, 0.0, true)
     val shell = new ShellEnvelope(0.0, 0.0, 0.0, true, 0.0, 10.0)
     assert(p1.intersects(shell))
+
+    val p2 = new Point3D(0.5, 0.0, 0.0, false)
+    val exception = intercept[AssertionError] {
+      p2.intersects(shell)
+    }
+    assert(exception.getMessage.contains("The 2 points must have the same coordinate system"))
   }
 
   test("Can you intersect a point and a Box?") {


### PR DESCRIPTION
This PR enforces that two point coordinates must be expressed in the same coordinate system to compute the distance between them.